### PR TITLE
Define manifest format and plugins structure

### DIFF
--- a/src/core/nodes.js
+++ b/src/core/nodes.js
@@ -225,10 +225,11 @@ limitations under the License.
           utils.createCommandsDispatcher(this.reducer, this.dispatch);
       this.settings = settings;
       this.origin = origin;
-      this.plugins = new Map();
       this.ready = new Promise(resolve => {
         this.markAsReady = resolve;
       });
+
+      this.uninstallPlugins = null;
     }
 
     get ref() {
@@ -251,9 +252,8 @@ limitations under the License.
 
     async init(container) {
       this.container = container;
-      this.renderer = new opr.Toolkit.Renderer(this, this.settings);
-      this.plugins = new opr.Toolkit.Plugins(this);
-      await this.plugins.installAll(this.settings.plugins);
+      this.renderer = new opr.Toolkit.Renderer(this);
+      this.uninstallPlugins = await opr.Toolkit.Plugins.install(this);
       const state = await this.getInitialState.call(this.sandbox, this.props);
       this.commands.init(state);
       this.markAsReady();
@@ -366,6 +366,7 @@ limitations under the License.
       const root = this.$root;
       Lifecycle.onComponentDestroyed(root);
       Lifecycle.onComponentDetached(root);
+      root.uninstallPlugins();
       root.ref = null;
       this.$root = null;
     }

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -17,8 +17,7 @@ limitations under the License.
 {
   class Renderer {
 
-    constructor(root, settings) {
-      this.settings = settings;
+    constructor(root) {
       this.root = root;
     }
 
@@ -34,7 +33,7 @@ limitations under the License.
     }
 
     updateDOM(command, prevState, nextState) {
-      if (this.debug) {
+      if (opr.Toolkit.settings.level === 'debug') {
         /* eslint-disable no-console */
         console.group('');
         console.log(
@@ -79,10 +78,6 @@ limitations under the License.
       }
 
       return patches;
-    }
-
-    get debug() {
-      return this.settings.level === 'debug';
     }
   }
 

--- a/src/core/toolkit.js
+++ b/src/core/toolkit.js
@@ -26,6 +26,7 @@ limitations under the License.
       this.readyPromise = new Promise(resolve => {
         initialize = resolve;
       });
+      this.assert = console.assert;
     }
 
     async ready() {
@@ -34,7 +35,6 @@ limitations under the License.
 
     async configure(options) {
       const settings = {};
-      settings.plugins = options.plugins || [];
       settings.level =
           LOG_LEVELS.includes(options.level) ? options.level : 'info';
       settings.debug = options.debug || false;
@@ -51,33 +51,12 @@ limitations under the License.
           await this.preload(module);
         }
       }
-      this.registerPlugins();
+      await opr.Toolkit.Plugins.register(options.plugins);
       initialize();
     }
 
-    registerPlugins() {
-      const context = {
-        registerComponentMethod: name =>
-            opr.Toolkit.Sandbox.registerPluginMethod(name),
-      };
-      for (const plugin of this.settings.plugins) {
-        if (typeof plugin.register === 'function') {
-          plugin.register(context);
-        }
-      }
-    }
-
     isDebug() {
-      return Boolean(this.settings) && this.settings.debug;
-    }
-
-    assert(condition, ...messages) {
-      if (this.isDebug()) {
-        console.assert(condition, ...messages);
-      }
-      if (!condition) {
-        throw new Error(messages.join(' '));
-      }
+      return Boolean(this.settings && this.settings.debug);
     }
 
     warn(...messages) {

--- a/src/core/virtual-dom.js
+++ b/src/core/virtual-dom.js
@@ -103,7 +103,7 @@ limitations under the License.
     static normalizeProps(ComponentClass, props = {}) {
       const defaultProps = ComponentClass.defaultProps;
       if (defaultProps) {
-        const result = Object.assign({}, props);
+        const result = {...props};
         const keys = Object.keys(defaultProps);
         for (const key of keys) {
           if (props[key] === undefined) {

--- a/src/debug.js
+++ b/src/debug.js
@@ -37,4 +37,10 @@ window.loadToolkit = async () => {
 
   window.opr = window.opr || {};
   window.opr.Toolkit = new Toolkit();
+
+  opr.Toolkit.assert = (condition, message) => {
+    if (!condition) {
+      throw new Error(message);
+    }
+  };
 };

--- a/test/config/init.js
+++ b/test/config/init.js
@@ -46,6 +46,12 @@ global.HTMLElement = class {};
 
   const toolkit = new Toolkit();
 
+  toolkit.assert = (condition, message) => {
+    if (!condition) {
+      throw new Error(message);
+    }
+  };
+
   global.opr = {
     Toolkit: toolkit,
   };


### PR DESCRIPTION
The plugin API should be flexible yet convenient:
- [x] define manifest format,
- [x] create plugin interface,
- [x] register plugins globally,
- [x] support permissions,
- [x] install locally to root components.