### PR TITLE
Allow plugins to inject stylesheets into root components

### DIFF
--- a/src/core/toolkit.js
+++ b/src/core/toolkit.js
@@ -44,14 +44,14 @@ limitations under the License.
           await this.preload(module);
         }
       }
-      this.plugins = await this.createPlugins(options.plugins);
+      this.plugins = this.createPlugins(options.plugins);
       this[INIT](true);
     }
 
-    async createPlugins(manifests = []) {
+    createPlugins(manifests = []) {
       const plugins = new opr.Toolkit.Plugins(null);
       for (const manifest of manifests) {
-        await plugins.install(manifest);
+        plugins.register(manifest);
       }
       return plugins;
     }

--- a/test/lifecycle.spec.js
+++ b/test/lifecycle.spec.js
@@ -8,7 +8,7 @@ describe('Lifecycle', () => {
   const Component = Symbol.for('Component');
   const Subcomponent = Symbol.for('Subcomponent');
 
-  const AbstractComponent = class extends opr.Toolkit.Component {
+  class AbstractComponent extends opr.Toolkit.Component {
     onCreated() {
       stub('onCreated', this);
     }
@@ -29,9 +29,9 @@ describe('Lifecycle', () => {
     }
   };
 
-  const App = class extends opr.Toolkit.Root {
+  class App extends opr.Toolkit.Root {
     constructor() {
-      super(container);
+      super(null, {}, opr.Toolkit);
     }
     onCreated() {
       stub('onCreated', this);
@@ -52,29 +52,33 @@ describe('Lifecycle', () => {
       stub('onDetached', this);
     }
   };
+
+  class SomeRoot extends opr.Toolkit.Root {
+    constructor() {
+      super(null, {}, opr.Toolkit);
+    }
+  }
 
   const createApp = template => {
-    const RootClass = class extends opr.Toolkit.Root {
+    class RootClass extends opr.Toolkit.Root {
       render() {
         return template;
       }
-    };
-    const app = new RootClass();
-    app.renderer = {
-      container: document.createElement('section'),
-    };
+    }
+    const root = new RootClass(null, {}, opr.Toolkit);
+    root.container = document.createElement('section');
 
     let node = null;
     if (template) {
       node = utils.createFromTemplate(template);
       if (node.isElement()) {
-        Patch.addElement(node, app).apply();
+        Patch.addElement(node, root).apply();
       }
       if (node.isComponent()) {
-        Patch.addComponent(node, app).apply();
+        Patch.addComponent(node, root).apply();
       }
     }
-    return [app, node];
+    return [root, node];
   };
 
   const ComponentClass = class extends AbstractComponent {
@@ -180,7 +184,7 @@ describe('Lifecycle', () => {
       it('adding component', () => {
 
         // given
-        const app = new opr.Toolkit.Root();
+        const app = new SomeRoot();
         const component = utils.createFromTemplate([Component]);
         const patches = [Patch.addComponent(component, app)];
 

--- a/test/nodes.spec.js
+++ b/test/nodes.spec.js
@@ -4,8 +4,14 @@ describe('Nodes', () => {
 
   const Component = Symbol.for('Component');
 
-  const App = class extends opr.Toolkit.Root {};
-  const ComponentClass = class extends opr.Toolkit.Component {
+  class SomeRoot extends opr.Toolkit.Root {
+    constructor() {
+      super(null, {}, opr.Toolkit);
+      this.container = document.createElement('main');
+    }
+  };
+
+  class ComponentClass extends opr.Toolkit.Component {
 
     render() {
       return this.children[0] || null;
@@ -46,9 +52,7 @@ describe('Nodes', () => {
     VirtualDOM.getComponentClass.restore();
   });
 
-  const root = new opr.Toolkit.Root({}, document.createElement('section'), {
-    plugins: [],
-  });
+  const root = new SomeRoot();
   const component = new opr.Toolkit.Component({}, [], null);
   const element = createElement('section');
   const comment = new opr.Toolkit.Comment('Dummy', null);
@@ -350,7 +354,7 @@ describe('Nodes', () => {
         const container = document.createElement('container');
         container.dispatchEvent = dispatchEvent;
 
-        const root = new opr.Toolkit.Root(null, {}, {});
+        const root = new SomeRoot();
         root.container = container;
         const element = createElement('section');
         root.appendChild(element);
@@ -683,7 +687,7 @@ describe('Nodes', () => {
 
     const container = document.createElement('body');
     const settings = {plugins: []};
-    const component = new opr.Toolkit.Root({}, settings);
+    const component = new SomeRoot();
     component.container = container;
 
     describe('get initial state', () => {
@@ -838,7 +842,7 @@ describe('Nodes', () => {
       it('creates a dispatcher', () => {
 
         // given
-        const root = new opr.Toolkit.Root();
+        const root = new SomeRoot();
         root.dispatch = sinon.spy();
         root.reducer = () => {};
         root.reducer.commands = {

--- a/test/patch-component.spec.js
+++ b/test/patch-component.spec.js
@@ -7,12 +7,12 @@ describe('Patch component => apply', () => {
   const Component = Symbol.for('Component');
   const Subcomponent = Symbol.for('Subcomponent');
 
-  const App = class extends opr.Toolkit.Root {
+  class SomeRoot extends opr.Toolkit.Root {
     constructor() {
-      super(null, {}, {});
+      super(null, {}, opr.Toolkit);
       this.container = container;
     }
-  };
+  }
   const ComponentClass = class extends opr.Toolkit.Component {
     render() {
       return this.children[0] || null;
@@ -46,7 +46,7 @@ describe('Patch component => apply', () => {
   });
 
   const createApp = template => {
-    const app = new App();
+    const app = new SomeRoot();
     Patch.initRootComponent(app).apply();
     let node = null;
     if (template) {
@@ -64,7 +64,7 @@ describe('Patch component => apply', () => {
   it('creates root component', () => {
 
     // given
-    const component = new App();
+    const component = new SomeRoot();
 
     // when
     Patch.initRootComponent(component).apply();
@@ -133,7 +133,7 @@ describe('Patch component => apply', () => {
       assert(app.comment);
       assert(app.comment.isComment());
       assert.equal(app.placeholder, app.comment);
-      assert(app.placeholder.text.includes('App'));
+      assert(app.placeholder.text.includes(SomeRoot.name));
 
       assert.equal(container.firstChild, app.comment.ref);
 
@@ -536,7 +536,7 @@ describe('Patch component => apply', () => {
       // then
       assert(app.placeholder);
       assert(app.placeholder.isComment());
-      assert(app.placeholder.text.includes('App'));
+      assert(app.placeholder.text.includes(SomeRoot.name));
 
       assert.equal(app.child, null);
 
@@ -635,7 +635,7 @@ describe('Patch component => apply', () => {
       // then
       assert(app.placeholder);
       assert(app.placeholder.isComment());
-      assert(app.placeholder.text.includes('App'));
+      assert(app.placeholder.text.includes(SomeRoot.name));
 
       assert.equal(app.child, null);
       assert.equal(component.parentNode, null);
@@ -664,7 +664,7 @@ describe('Patch component => apply', () => {
       // then
       assert(app.placeholder);
       assert(app.placeholder.isComment());
-      assert(app.placeholder.text.includes('App'));
+      assert(app.placeholder.text.includes(SomeRoot.name));
 
       assert.equal(app.child, null);
       assert.equal(component.parentNode, null);

--- a/test/renderer.spec.js
+++ b/test/renderer.spec.js
@@ -2,10 +2,15 @@ describe('Renderer', () => {
 
   const Renderer = opr.Toolkit.Renderer;
 
+  class SomeRoot extends opr.Toolkit.Root {
+    constructor() {
+      super(null, {}, opr.Toolkit);
+    }
+  }
+
   const createRenderer = () => {
-    const root = new opr.Toolkit.Root();
-    const settings = {};
-    return new opr.Toolkit.Renderer(root, settings);
+    const root = new SomeRoot();
+    return new opr.Toolkit.Renderer(root);
   };
 
   it('returns empty list of patches for equal states', () => {

--- a/test/sandbox.spec.js
+++ b/test/sandbox.spec.js
@@ -2,6 +2,12 @@ describe('Sandbox', () => {
 
   const Sandbox = opr.Toolkit.Sandbox;
 
+  class SomeRoot extends opr.Toolkit.Root {
+    constructor() {
+      super(null, {}, opr.Toolkit);
+    }
+  }
+
   describe('create sandbox', () => {
 
     it('returns a sandbox containing own methods', () => {
@@ -91,7 +97,7 @@ describe('Sandbox', () => {
     it('allows to get root state as props', () => {
 
       // given
-      const root = new opr.Toolkit.Root();
+      const root = new SomeRoot();
       root.state = {
         foo: 'bar',
       };
@@ -122,7 +128,7 @@ describe('Sandbox', () => {
 
       // given
       const dispatch = () => {};
-      const component = new opr.Toolkit.Root();
+      const component = new SomeRoot();
       component.dispatch = dispatch;
 
       // when

--- a/test/virtual-dom-create-component.spec.js
+++ b/test/virtual-dom-create-component.spec.js
@@ -1,9 +1,16 @@
 describe('Virtual DOM', () => {
 
   const {Renderer, VirtualDOM} = opr.Toolkit;
-
   const container = document.createElement('container');
-  const root = new opr.Toolkit.Root({}, container, {});
+
+  class SomeRoot extends opr.Toolkit.Root {
+    constructor() {
+      super(null, {}, opr.Toolkit);
+      this.container = container;
+    }
+  }
+
+  const root = new SomeRoot();
 
   const render = (symbol, props) => {
     const component = VirtualDOM.createComponent(symbol, props, [], root, root);

--- a/test/virtual-dom.spec.js
+++ b/test/virtual-dom.spec.js
@@ -241,7 +241,13 @@ describe('Virtual DOM', () => {
       }
     }
 
-    const root = new opr.Toolkit.Root();
+    class SomeRoot extends opr.Toolkit.Root {
+      constructor() {
+        super(null, {}, opr.Toolkit);
+      }
+    }
+
+    const root = new SomeRoot();
 
     beforeEach(() => {
       sinon.stub(VirtualDOM, 'getComponentClass')


### PR DESCRIPTION
- [x] create new permission: "inject-stylesheets",
- [x] extend root stylesheets with the list provided by plugin's getStylesheets() method.