### PR TITLE
Tailor the reconciliation algorythm for drag'n'drop

### DIFF
--- a/dist/toolkit.release.js
+++ b/dist/toolkit.release.js
@@ -1513,7 +1513,11 @@ limitations under the License.
         assertUniqueKeys(to);
       }
 
-      const moves = Reconciler.calculateMoves(from, to);
+      const nodeFavoredToMove =
+          current.find(node => node.props && node.props.beingDragged);
+
+      const moves = Reconciler.calculateMoves(
+          from, to, nodeFavoredToMove && nodeFavoredToMove.key);
 
       const children = [...current];
       for (const move of moves) {
@@ -2612,8 +2616,7 @@ limitations under the License.
       return a.key > b.key ? 1 : -1;
     }
 
-    static calculateMoves(source, target) {
-
+    static calculateMoves(source, target, favoredToMove = null) {
       const moves = [];
 
       const createItem = function(key, index) {
@@ -2699,17 +2702,16 @@ limitations under the License.
       };
 
       const defaultMoves = calculateIndexChanges([...result], target);
-      if (defaultMoves.length > 1) {
+      if (defaultMoves.length > 1 ||
+          favoredToMove && defaultMoves.length === 1 &&
+              defaultMoves[0].item !== favoredToMove) {
         const alternativeMoves =
             calculateIndexChanges([...result], target, /*= reversed*/ true);
-        if (alternativeMoves.length < defaultMoves.length) {
+        if (alternativeMoves.length <= defaultMoves.length) {
           moves.push(...alternativeMoves);
           moves.result = alternativeMoves.result;
-        } else {
-          moves.push(...defaultMoves);
-          moves.result = defaultMoves.result;
+          return moves;
         }
-        return moves;
       }
       moves.push(...defaultMoves);
       moves.result = defaultMoves.result;

--- a/src/core/diff.js
+++ b/src/core/diff.js
@@ -283,7 +283,11 @@ limitations under the License.
         assertUniqueKeys(to);
       }
 
-      const moves = Reconciler.calculateMoves(from, to);
+      const nodeFavoredToMove =
+          current.find(node => node.props && node.props.beingDragged);
+
+      const moves = Reconciler.calculateMoves(
+          from, to, nodeFavoredToMove && nodeFavoredToMove.key);
 
       const children = [...current];
       for (const move of moves) {

--- a/src/core/reconciler.js
+++ b/src/core/reconciler.js
@@ -61,8 +61,7 @@ limitations under the License.
       return a.key > b.key ? 1 : -1;
     }
 
-    static calculateMoves(source, target) {
-
+    static calculateMoves(source, target, favoredToMove = null) {
       const moves = [];
 
       const createItem = function(key, index) {
@@ -148,17 +147,16 @@ limitations under the License.
       };
 
       const defaultMoves = calculateIndexChanges([...result], target);
-      if (defaultMoves.length > 1) {
+      if (defaultMoves.length > 1 ||
+          favoredToMove && defaultMoves.length === 1 &&
+              defaultMoves[0].item !== favoredToMove) {
         const alternativeMoves =
             calculateIndexChanges([...result], target, /*= reversed*/ true);
-        if (alternativeMoves.length < defaultMoves.length) {
+        if (alternativeMoves.length <= defaultMoves.length) {
           moves.push(...alternativeMoves);
           moves.result = alternativeMoves.result;
-        } else {
-          moves.push(...defaultMoves);
-          moves.result = defaultMoves.result;
+          return moves;
         }
-        return moves;
       }
       moves.push(...defaultMoves);
       moves.result = defaultMoves.result;

--- a/test/diff-calculate.spec.js
+++ b/test/diff-calculate.spec.js
@@ -776,8 +776,8 @@ describe('Diff => calculate patches', () => {
 
           // then
           assert.equal(patches.length, 2);
-          assertMoveChildNode(patches[0], 'Y', 3, 1);
-          assertMoveChildNode(patches[1], 'div', 3, 2);
+          assertMoveChildNode(patches[0], 'X', 1, 3);
+          assertMoveChildNode(patches[1], 'div', 1, 2);
         });
 
         it('swaps three elements', () => {


### PR DESCRIPTION
Nodes moved because of the reconciliation of the child nodes are not animated because they get detached and attached back to the parent. So when possible it should be possible to specify the node favoured to be moved (e.g. the node being dragged) if the single move operation is needed, to animate correctly all other nodes.
